### PR TITLE
Dans chaque tables :

### DIFF
--- a/models/intermediate/colleges_IPS_ALL.sql
+++ b/models/intermediate/colleges_IPS_ALL.sql
@@ -1,0 +1,14 @@
+SELECT 
+    uai,
+  CASE -- Transformation d’année : 2020 → 2021, 2021 → 2022
+    WHEN annee = 2020 THEN 2021
+    WHEN annee = 2021 THEN 2022
+    ELSE annee
+  END AS annee,
+    code_dep,
+    ips,
+    ips_sigma,
+
+FROM {{ ref('stg_clean__IPS_colleges') }}
+
+WHERE annee IN (2021, 2022) 

--- a/models/intermediate/colleges_IPS_IDF.sql
+++ b/models/intermediate/colleges_IPS_IDF.sql
@@ -1,0 +1,15 @@
+SELECT
+  uai,
+  CASE -- Transformation d’année : 2020 → 2021, 2021 → 2022
+    WHEN annee = 2020 THEN 2021
+    WHEN annee = 2021 THEN 2022
+    ELSE annee
+  END AS annee,
+
+    code_dep,
+    ips,
+    ips_sigma,
+
+FROM {{ ref('stg_clean__IPS_colleges') }}
+
+WHERE annee IN (2021, 2022) AND code_dep IN ("075", "077", "078", "091", "092", "093", "094", "095")

--- a/models/intermediate/colleges_IVA_ALL.sql
+++ b/models/intermediate/colleges_IVA_ALL.sql
@@ -1,0 +1,17 @@
+SELECT 
+  pk,
+  annee,
+  uai,
+  nb_candidats_g,
+  taux_reussite_g,
+  note_g,
+  taux_acces_6_3,
+  nb_mention_tb_g,
+  nb_mention_g,
+  va_taux_reussite_g,
+  va_note_g,
+  LPAD(code_dep, 3, '0') AS code_dep, -- transforme le 'taille' de la string 'code_dep' 
+  nb_mention_tb_g + nb_mention_g AS mentions_total
+
+FROM {{ ref('stg_clean__iva_colleges') }}
+WHERE annee in (2022)

--- a/models/intermediate/colleges_IVA_IDF.sql
+++ b/models/intermediate/colleges_IVA_IDF.sql
@@ -1,0 +1,18 @@
+
+SELECT 
+  pk,
+  annee,
+  uai,
+  nb_candidats_g,
+  taux_reussite_g,
+  note_g,
+  taux_acces_6_3,
+  nb_mention_tb_g,
+  nb_mention_g,
+  va_taux_reussite_g,
+  va_note_g,
+  LPAD(code_dep, 3, '0') AS code_dep, -- transforme le 'taille' de la string 'code_dep' 
+  nb_mention_tb_g + nb_mention_g AS mentions_total
+
+FROM {{ ref('stg_clean__iva_colleges') }}
+WHERE annee in (2022) AND LPAD(code_dep, 3, '0') IN ("075", "077", "078", "091", "092", "093", "094", "095")

--- a/models/intermediate/effectif_colleges_ALL.sql
+++ b/models/intermediate/effectif_colleges_ALL.sql
@@ -1,0 +1,15 @@
+SELECT
+    uai,
+    annee,
+    LPAD(code_dep, 3, '0') AS code_dep, -- transforme le 'taille' de la string 'code_dep'  
+    rep,
+    rep_plus,	
+    nb_eleves,	
+    nb_3_all,	
+    nb_3,
+    nb_3_segpa,
+    nb_3_ulis,
+
+
+FROM {{ ref('stg_clean__effectif_colleges') }}
+WHERE annee IN (2021, 2022) 

--- a/models/intermediate/effectif_colleges_IDF.sql
+++ b/models/intermediate/effectif_colleges_IDF.sql
@@ -1,0 +1,14 @@
+SELECT
+    uai,
+    annee,
+    LPAD(code_dep, 3, '0') AS code_dep, -- transforme le 'taille' de la string 'code_dep'  
+    rep,
+    rep_plus,	
+    nb_eleves,	
+    nb_3_all,	
+    nb_3,
+    nb_3_segpa,
+    nb_3_ulis,
+
+FROM {{ ref('stg_clean__effectif_colleges') }}
+WHERE annee IN (2021, 2022) AND LPAD(code_dep, 3, '0') IN ("075", "077", "078", "091", "092", "093", "094", "095")


### PR DESCRIPTION
Dans toutes les tables : 
- Standardisation des code_dep ( 3 chiffres) 
Dans les tables IPS :
- Modification de l'année 2020 -> 2021 et 2021 -> 2022 
Dans les tables "ALL" :
- filtre sur l'année 2021 -2022 
Dans les tables "IDF" :
- filtre sur l'année 2021-2022 et sur les code_dp (idf)